### PR TITLE
add resource event

### DIFF
--- a/client/include/zigen-playground.h
+++ b/client/include/zigen-playground.h
@@ -59,6 +59,7 @@ class Playground : public std::enable_shared_from_this<Playground>,
 
   void NoopEvent();
   void SyncEvent(std::vector<std::shared_ptr<model::Resource>> resources);
+  void NewResourceEvent(std::shared_ptr<model::Resource> resource);
   void ClientErrorEvent(std::string reason);
 
   void DndNewResource(std::string resource_type, glm::vec3 position);

--- a/client/playground/client.h
+++ b/client/playground/client.h
@@ -28,6 +28,8 @@ class Client : public std::enable_shared_from_this<Client> {
   void ConnectSyncEventSignal(
       std::function<void(std::vector<std::shared_ptr<model::Resource>>)>
           observer);
+  void ConnectNewResourceEventSignal(
+      std::function<void(std::shared_ptr<model::Resource>)> observer);
   void ConnectErrorSignal(std::function<void(std::string)> observer);
 
   void SyncRequest();

--- a/client/playground/client/client-impl.cc
+++ b/client/playground/client/client-impl.cc
@@ -11,6 +11,7 @@
 #include "message-parser.h"
 #include "message.h"
 #include "message/error.h"
+#include "message/new-resource-event.h"
 #include "message/new-resource-request.h"
 #include "message/noop-event.h"
 #include "message/sync-event.h"
@@ -135,6 +136,11 @@ void Client::Impl::OnEvent() {
         sync.Load(data);
         auto resources = sync.GetResources();
         sync_event_signal(resources);
+      } else if (handling_event_ == message::Action::kNewResourceEvent) {
+        auto new_resource_event = message::NewResourceEvent();
+        new_resource_event.Load(data);
+        auto resource = new_resource_event.GetResource();
+        if (resource) new_resource_event_signal(resource);
       }
 
       free(data);

--- a/client/playground/client/client-impl.h
+++ b/client/playground/client/client-impl.h
@@ -31,6 +31,8 @@ class Client::Impl : public std::enable_shared_from_this<Impl> {
   boost::signals2::signal<void()> noop_event_signal;
   boost::signals2::signal<void(std::vector<std::shared_ptr<model::Resource>>)>
       sync_event_signal;
+  boost::signals2::signal<void(std::shared_ptr<model::Resource>)>
+      new_resource_event_signal;
   boost::signals2::signal<void(std::string)> error_signal;
 
  private:

--- a/client/playground/client/client.cc
+++ b/client/playground/client/client.cc
@@ -35,6 +35,11 @@ void Client::ConnectSyncEventSignal(
   pimpl_->sync_event_signal.connect(observer);
 }
 
+void Client::ConnectNewResourceEventSignal(
+    std::function<void(std::shared_ptr<model::Resource>)> observer) {
+  pimpl_->new_resource_event_signal.connect(observer);
+}
+
 void Client::ConnectErrorSignal(std::function<void(std::string)> observer) {
   pimpl_->error_signal.connect(observer);
 }

--- a/client/playground/client/meson.build
+++ b/client/playground/client/meson.build
@@ -9,6 +9,7 @@ srcs_zigen_playground_client = [
   'message-parser.cc',
   'messaging.cc',
   'message/error.cc',
+  'message/new-resource-event.cc',
   'message/new-resource-request.cc',
   'message/noop-event.cc',
   'message/sync-event.cc',

--- a/client/playground/client/message-parser.cc
+++ b/client/playground/client/message-parser.cc
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "message/error.h"
+#include "message/new-resource-event.h"
 #include "message/noop-event.h"
 #include "message/sync-event.h"
 
@@ -23,6 +24,9 @@ std::shared_ptr<message::IMessage> MessageParser::ParseEvent(std::string json) {
   if (*action == "noop") return std::make_shared<message::NoopEvent>();
 
   if (*action == "sync") return std::make_shared<message::SyncEvent>(json);
+
+  if (*action == "new-resource")
+    return std::make_shared<message::NewResourceEvent>(json);
 
   return std::make_shared<message::Error>("invalid action: " + *action);
 }

--- a/client/playground/client/message.h
+++ b/client/playground/client/message.h
@@ -10,6 +10,7 @@ namespace message {
 
 enum class Action : uint32_t {
   kUnset,
+  kNewResourceEvent,
   kNewResourceRequest,
   kNoopEvent,
   kSyncEvent,

--- a/client/playground/client/message/helper.h
+++ b/client/playground/client/message/helper.h
@@ -1,0 +1,22 @@
+#ifndef ZIGEN_PLAYGROUND_MESSAGE_HELPER_H
+#define ZIGEN_PLAYGROUND_MESSAGE_HELPER_H
+
+namespace zigen_playground {
+namespace message {
+
+static glm::vec3 ToVec3(boost::property_tree::ptree const &pt,
+    boost::property_tree::ptree::key_type const &key) {
+  glm::vec3 v;
+  int i = 0;
+  for (auto &item : pt.get_child(key)) {
+    v[i++] = item.second.get_value<float>();
+    if (i >= 3) break;
+  }
+
+  return v;
+}
+
+}  // namespace message
+}  // namespace zigen_playground
+
+#endif  //  ZIGEN_PLAYGROUND_MESSAGE_HELPER_H

--- a/client/playground/client/message/new-resource-event.cc
+++ b/client/playground/client/message/new-resource-event.cc
@@ -1,0 +1,64 @@
+#include "new-resource-event.h"
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "helper.h"
+
+namespace zigen_playground {
+namespace message {
+
+NewResourceEvent::NewResourceEvent() {}
+
+NewResourceEvent::NewResourceEvent(std::string json) : json_(json) {}
+
+bool NewResourceEvent::WriteTo(int fd) {
+  uint32_t size = json_.size();
+
+  if (write(fd, &size, sizeof(uint32_t)) != sizeof(uint32_t)) return false;
+
+  return write(fd, json_.c_str(), json_.size()) ==
+         static_cast<ssize_t>(json_.size());
+}
+
+bool NewResourceEvent::Load(void *data) {
+  uint32_t size = reinterpret_cast<uint32_t *>(data)[0];
+  char *str = reinterpret_cast<char *>(data) + 4;
+  json_ = std::string(str, size);
+  return true;
+}
+
+uint32_t NewResourceEvent::GetSize() { return sizeof(uint32_t) + json_.size(); }
+
+message::Action NewResourceEvent::GetAction() {
+  return message::Action::kNewResourceEvent;
+}
+
+std::shared_ptr<model::Resource> NewResourceEvent::GetResource() {
+  std::stringstream ss;
+  boost::property_tree::ptree property_tree;
+
+  ss << json_;
+  boost::property_tree::read_json(ss, property_tree);
+
+  auto type = property_tree.get<std::string>("data.type");
+
+  if (type == "cuboid") {
+    glm::vec3 position = ToVec3(property_tree, "data.position");
+    glm::vec3 half_size = ToVec3(property_tree, "data.half_size");
+
+    return std::make_shared<model::Cuboid>(position, half_size);
+  } else if (type == "sphere") {
+    glm::vec3 position = ToVec3(property_tree, "data.position");
+    float r = property_tree.get<float>("data.r");
+    uint32_t resolution = property_tree.get<uint32_t>("data.resolution");
+    std::string texture = property_tree.get<std::string>("data.texture");
+
+    return std::make_shared<model::Sphere>(position, r, resolution, texture);
+  }
+
+  return std::shared_ptr<model::Resource>();
+}
+
+}  // namespace message
+}  // namespace zigen_playground

--- a/client/playground/client/message/new-resource-event.h
+++ b/client/playground/client/message/new-resource-event.h
@@ -1,5 +1,5 @@
-#ifndef ZIGEN_PLAYGROUND_MESSAGES_SYNC_EVENT_H
-#define ZIGEN_PLAYGROUND_MESSAGES_SYNC_EVENT_H
+#ifndef ZIGEN_PLAYGROUND_MESSAGES_NEW_RESOURCE_EVENT_H
+#define ZIGEN_PLAYGROUND_MESSAGES_NEW_RESOURCE_EVENT_H
 
 #include <vector>
 
@@ -9,10 +9,10 @@
 namespace zigen_playground {
 namespace message {
 
-class SyncEvent : public IMessage {
+class NewResourceEvent : public IMessage {
  public:
-  SyncEvent();
-  SyncEvent(std::string json);
+  NewResourceEvent();
+  NewResourceEvent(std::string json);
 
   virtual bool WriteTo(int fd) override final;
 
@@ -22,7 +22,7 @@ class SyncEvent : public IMessage {
 
   virtual message::Action GetAction() override final;
 
-  std::vector<std::shared_ptr<model::Resource>> GetResources();
+  std::shared_ptr<model::Resource> GetResource();
 
  private:
   std::string json_;
@@ -31,4 +31,4 @@ class SyncEvent : public IMessage {
 }  // namespace message
 }  // namespace zigen_playground
 
-#endif  //  ZIGEN_PLAYGROUND_MESSAGES_SYNC_EVENT_H
+#endif  //  ZIGEN_PLAYGROUND_MESSAGES_NEW_RESOURCE_EVENT_H

--- a/client/playground/client/message/sync-event.cc
+++ b/client/playground/client/message/sync-event.cc
@@ -5,20 +5,10 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include "helper.h"
+
 namespace zigen_playground {
 namespace message {
-
-glm::vec3 ToVec3(boost::property_tree::ptree const &pt,
-    boost::property_tree::ptree::key_type const &key) {
-  glm::vec3 v;
-  int i = 0;
-  for (auto &item : pt.get_child(key)) {
-    v[i++] = item.second.get_value<float>();
-    if (i >= 3) break;
-  }
-
-  return v;
-}
 
 SyncEvent::SyncEvent() {}
 

--- a/client/playground/playground-view.cc
+++ b/client/playground/playground-view.cc
@@ -170,4 +170,25 @@ void PlaygroundView::Sync(
   virtual_object_->ScheduleNextFrame();
 }
 
+void PlaygroundView::AddResource(std::shared_ptr<model::Resource> resource) {
+  if (resource->type == "cuboid") {
+    auto cuboid = std::dynamic_pointer_cast<model::Cuboid>(resource);
+    auto cuboid_view =
+        std::make_shared<CuboidView>(app_, virtual_object_, cuboid);
+    cuboid_views_.push_back(cuboid_view);
+    object_group_->AddObject(cuboid_view);
+    cuboid_view->Init();
+    cuboid_view->SetGeometry(position_, quaternion_);
+  } else if (resource->type == "sphere") {
+    auto sphere = std::dynamic_pointer_cast<model::Sphere>(resource);
+    auto sphere_view =
+        std::make_shared<SphereView>(app_, virtual_object_, sphere);
+    sphere_views_.push_back(sphere_view);
+    object_group_->AddObject(sphere_view);
+    sphere_view->Init();
+    sphere_view->SetGeometry(position_, quaternion_);
+  }
+
+  virtual_object_->ScheduleNextFrame();
+}
 }  // namespace zigen_playground

--- a/client/playground/playground-view.h
+++ b/client/playground/playground-view.h
@@ -41,6 +41,8 @@ class PlaygroundView : public zukou::objects::IObject {
 
   void Sync(std::vector<std::shared_ptr<model::Resource>> resources);
 
+  void AddResource(std::shared_ptr<model::Resource> resource);
+
   // callbacks
   std::function<void(std::string resource_type, glm::vec3 position)>
       dnd_new_resource_callback;

--- a/client/playground/playground.cc
+++ b/client/playground/playground.cc
@@ -38,6 +38,8 @@ bool Playground::Init() {
   client_->ConnectNoopEventSignal(std::bind(&Playground::NoopEvent, self));
   client_->ConnectSyncEventSignal(
       std::bind(&Playground::SyncEvent, self, std::placeholders::_1));
+  client_->ConnectNewResourceEventSignal(
+      std::bind(&Playground::NewResourceEvent, self, std::placeholders::_1));
   client_->ConnectErrorSignal(
       std::bind(&Playground::ClientErrorEvent, self, std::placeholders::_1));
 
@@ -89,6 +91,11 @@ void Playground::SyncEvent(
     std::vector<std::shared_ptr<model::Resource>> resources) {
   std::cerr << "[event] sync" << std::endl;
   view_->Sync(resources);
+}
+
+void Playground::NewResourceEvent(std::shared_ptr<model::Resource> resource) {
+  std::cerr << "[event] new resource" << std::endl;
+  view_->AddResource(resource);
 }
 
 void Playground::Connect([[maybe_unused]] const error_signal signal,

--- a/client/playground/sphere-view.cc
+++ b/client/playground/sphere-view.cc
@@ -159,11 +159,6 @@ void SphereView::OnTextureLoaded(uint32_t width, uint32_t height,
     std::function<void(void *data)> writer) {
   uint32_t element_count;
 
-  (void)width;
-  (void)height;
-  (void)writer;
-  (void)element_count;
-
   // shader
   auto transform = GetTransformMatrix();
   shader_ = zukou::OpenGLShaderProgram::Create(app_);

--- a/server/controller/new_resource.ts
+++ b/server/controller/new_resource.ts
@@ -1,7 +1,8 @@
-import SyncEvent from '../event/sync'
+import NewResourceEvent from '../event/new_resource'
 import { Vector3 } from '../math/vector'
 import Client from '../model/client'
 import Playground from '../model/playground'
+import Resource from '../model/resource'
 import Cuboid from '../model/resource/cuboid'
 import Sphere from '../model/resource/sphere'
 import NewResourceRequest from '../request/new_resource'
@@ -12,16 +13,20 @@ export const newResourceController = (
 ) => {
   const playground = Playground.get()
 
+  let resource: Resource
+
   if (request.type === 'cuboid') {
-    playground.resources.push(
-      new Cuboid(request.position, new Vector3(0.01, 0.01, 0.01))
-    )
+    resource = new Cuboid(request.position, new Vector3(0.01, 0.01, 0.01))
   } else if (request.type === 'sphere') {
-    playground.resources.push(new Sphere(request.position, 0.02, 4))
+    resource = new Sphere(request.position, 0.02, 4)
+  } else {
+    return
   }
 
+  playground.resources.push(resource)
+
   playground.forEachClients((client) => {
-    const syncEvent = new SyncEvent(playground)
-    syncEvent.send(client)
+    const newResourceEvent = new NewResourceEvent(resource)
+    newResourceEvent.send(client)
   })
 }

--- a/server/event/new_resource.ts
+++ b/server/event/new_resource.ts
@@ -1,0 +1,17 @@
+import Client from '../model/client'
+import Resource from '../model/resource'
+
+class NewResourceEvent {
+  constructor(private resource: Resource) {}
+
+  send = (client: Client) => {
+    const data = {
+      action: 'new-resource',
+      data: this.resource.serialize(),
+    }
+    const json = JSON.stringify(data)
+    client.send(json)
+  }
+}
+
+export default NewResourceEvent

--- a/server/index.ts
+++ b/server/index.ts
@@ -72,7 +72,7 @@ playground.resources.push(
     new Vector3(-0.1, 0.06, 0.12),
     0.05,
     10,
-    'https://www.solarsystemscope.com/textures/download/8k_moon.jpg'
+    'https://www.solarsystemscope.com/textures/download/2k_moon.jpg'
   )
 )
 


### PR DESCRIPTION
cuboid や sphere などのresourceをdndなどで追加した時に、今まではsyncイベントを飛ばして、全部再描画させていたが、add resource eventによって、追加分だけ描画するようにした。